### PR TITLE
Fix normalized time mapping

### DIFF
--- a/src/utils/animation.test.ts
+++ b/src/utils/animation.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { frameToNormalizedTime, normalizedTimeToFrame } from "./animation";
+
+describe("frameToNormalizedTime", () => {
+  it("maps first and last frame correctly", () => {
+    expect(frameToNormalizedTime(0, 60)).toBe(0);
+    expect(frameToNormalizedTime(59, 60)).toBe(1);
+  });
+
+  it("is inverse of normalizedTimeToFrame for intermediate frames", () => {
+    const total = 60;
+    for (let frame = 0; frame < total - 1; frame++) {
+      const t = frameToNormalizedTime(frame, total);
+      expect(normalizedTimeToFrame(t, total)).toBe(frame);
+    }
+    // Last frame loops back to 0 when converting back
+    const lastT = frameToNormalizedTime(total - 1, total);
+    expect(normalizedTimeToFrame(lastT, total)).toBe(0);
+  });
+});

--- a/src/utils/animation.ts
+++ b/src/utils/animation.ts
@@ -30,8 +30,14 @@ export const frameToNormalizedTime = (
   // Ensure frame is within valid range
   const clampedFrame = Math.max(0, Math.min(totalFrames - 1, frame));
 
+  // Avoid divide-by-zero and match AnimationController.normalizedTime
+  if (totalFrames <= 1) {
+    return 0;
+  }
+
   // Convert to normalized time (0-1)
-  return clampedFrame / totalFrames;
+  // Use totalFrames - 1 so the last frame maps exactly to 1
+  return clampedFrame / (totalFrames - 1);
 };
 
 /**


### PR DESCRIPTION
## Summary
- fix `frameToNormalizedTime` calculation in animation utilities
- add unit tests for the updated function

## Testing
- `npm test` *(fails: vitest not found)*