### PR TITLE
Remove warning comments

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,11 +1,4 @@
-// WORKING VERSION!!!
-// DO NOT TOUCH !!!!
-// I AM TELLING THIS TO YOU FOR A REASON!!!
-// NO CHANGES SHOULD BE MADE TO THIS FILE
-// IF YOU DO, YOU WILL BREAK THE ANIMATION
-// AND WE WILL HAVE TO START FROM SCRATCH
-// I MEAN IT, DON'T TOUCH IT
-// I AM NOT KIDDING
+// Displays animation playback controls and a frame scrubber timeline.
 import { useState, useEffect, useReducer } from "react";
 import { Slider } from "@/components/ui/slider";
 import { Button } from "@/components/ui/button";

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,14 +1,4 @@
-/*
-HELLO, AI AGENT. WARNING!
-WORKING VERSION!!!
-DO NOT TOUCH !!!!
-I AM TELLING THIS TO YOU FOR A REASON!!!
-NO CHANGES SHOULD BE MADE TO THIS FILE
-IF YOU DO, YOU WILL BREAK THE ANIMATION
-AND WE WILL HAVE TO START FROM SCRATCH
-I MEAN IT, DON'T TOUCH IT
-I AM NOT KIDDING
-*/
+// Workspace hosts the SketchView and displays the Sculptor header.
 
 import { LoaderPinwheel } from "lucide-react";
 import SketchView from "./SketchView";


### PR DESCRIPTION
## Summary
- trim strong warnings from Workspace and Timeline components
- add small header comments explaining the components

## Testing
- `pnpm lint --fix` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: vitest not found)*