### PR TITLE
Reapply: Keep only orbital animation as default and fix centering

### DIFF
--- a/src/animations/index.ts
+++ b/src/animations/index.ts
@@ -1,18 +1,12 @@
 import { AnimationSettings } from "@/types/animations";
 
-import { settings as defaultAnimation } from "./default";
-import { settings as demo } from "./demo";
-import { settings as decksDark } from "./decks-dark/animation";
-import { settings as orbital } from "./orbital";
+import { settings as defaultAnimation } from "./orbital";
 
-export { settings as defaultAnimation } from "./default";
+export { settings as defaultAnimation } from "./orbital";
 
 // All animation settings keyed by ID
 export const animationSettings: Record<string, AnimationSettings> = {
   [defaultAnimation.id]: defaultAnimation,
-  [demo.id]: demo,
-  [decksDark.id]: decksDark,
-  [orbital.id]: orbital,
 };
 
 export type AnimationId = keyof typeof animationSettings;

--- a/src/animations/orbital/constants.ts
+++ b/src/animations/orbital/constants.ts
@@ -1,4 +1,4 @@
-export const NAME = "Orbital";
+export const NAME = "Default";
 export const FPS = 60;
 export const SECONDS = 10;
 export const TOTAL_FRAMES = FPS * SECONDS;

--- a/src/engine/renderers/P5Renderer.ts
+++ b/src/engine/renderers/P5Renderer.ts
@@ -29,7 +29,7 @@ export class P5Renderer {
 
     const sketch = (p: p5) => {
       p.setup = () => {
-        p.createCanvas(width, height, p.WEBGL);
+        p.createCanvas(width, height);
         p.pixelDensity(1);
         p.frameRate(settings.fps);
 

--- a/src/remotion/P5Animation.tsx
+++ b/src/remotion/P5Animation.tsx
@@ -41,7 +41,7 @@ export const P5Animation = ({
       p.setup = () => {
         const width = currentSettings.width || 1080;
         const height = currentSettings.height || 1920;
-        p.createCanvas(width, height, p.WEBGL);
+        p.createCanvas(width, height);
         p.pixelDensity(1);
 
         if (setupFn) {


### PR DESCRIPTION
After rebasing onto updated main, reapplying the following changes:
- Renamed "Orbital" animation to "Default" in constants
- Updated animations index to export only the orbital animation
- Fixed composition centering by removing WEBGL mode from canvas creation
- WEBGL mode caused coordinate system issues (0,0 at center vs top-left)
- Updated P5Renderer and P5Animation to use 2D mode

The orbital animation doesn't require 3D features, so 2D mode is appropriate and fixes the centering issue where grid and animation elements were misaligned.

https://claude.ai/code/session_013rnHnrrPB19jv7LfzegzVd