### PR TITLE
Refactor renderer initialization to use useEffect instead of callback

### DIFF
--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -21,30 +21,34 @@ export function usePlayback() {
   const settings =
     animationSettings[selectedAnimationId] || defaultAnimation;
 
+  // Ref callback to store container reference
+  const setContainerRef = useCallback((container: HTMLElement | null) => {
+    containerRef.current = container;
+  }, []);
+
   // Initialize renderer when animation changes or container is set
-  const initRenderer = useCallback(
-    (container: HTMLElement | null) => {
-      containerRef.current = container;
+  useEffect(() => {
+    const container = containerRef.current;
 
-      if (rendererRef.current) {
-        rendererRef.current.destroy();
-        rendererRef.current = null;
-      }
+    // Clean up existing renderer
+    if (rendererRef.current) {
+      rendererRef.current.destroy();
+      rendererRef.current = null;
+    }
 
-      if (!container) return;
+    if (!container) return;
 
-      const renderer = createRenderer(settings.renderer);
-      renderer.initialize(container, settings);
-      rendererRef.current = renderer;
+    // Create and initialize new renderer
+    const renderer = createRenderer(settings.renderer);
+    renderer.initialize(container, settings);
+    rendererRef.current = renderer;
 
-      // Draw initial frame
-      const totalFrames = settings.totalFrames;
-      const normalizedTime =
-        totalFrames > 1 ? currentFrame / (totalFrames - 1) : 0;
-      renderer.renderFrame({ normalizedTime, currentFrame, totalFrames });
-    },
-    [selectedAnimationId] // Only reinit when animation changes
-  );
+    // Draw initial frame
+    const totalFrames = settings.totalFrames;
+    const normalizedTime =
+      totalFrames > 1 ? currentFrame / (totalFrames - 1) : 0;
+    renderer.renderFrame({ normalizedTime, currentFrame, totalFrames });
+  }, [selectedAnimationId, settings, currentFrame]);
 
   // Redraw when frame changes (scrubbing or playback)
   useEffect(() => {
@@ -86,5 +90,5 @@ export function usePlayback() {
     };
   }, []);
 
-  return { containerRef: initRenderer, settings };
+  return { containerRef: setContainerRef, settings };
 }


### PR DESCRIPTION
## Summary
Refactored the renderer initialization logic in `usePlayback` hook to separate concerns between storing the container reference and initializing the renderer. The initialization is now handled by a `useEffect` hook instead of a callback, allowing proper dependency tracking and ensuring the renderer is reinitialized when animation settings or current frame changes.

## Key Changes
- Extracted container reference storage into a separate `setContainerRef` callback
- Moved renderer initialization logic from `initRenderer` callback into a `useEffect` hook
- Updated dependency array to include `settings` and `currentFrame` in addition to `selectedAnimationId`, ensuring the renderer reinitializes when these values change
- Simplified the return value to export `setContainerRef` instead of `initRenderer`

## Implementation Details
- The `setContainerRef` callback is now a simple ref setter with no side effects
- Renderer initialization now properly responds to changes in animation settings and current frame, not just animation selection
- The effect properly cleans up the previous renderer before creating a new one
- Initial frame rendering is now part of the effect's initialization sequence

https://claude.ai/code/session_0158U2Q9H5wzW84xpNtsC35R