### PR TITLE
Refactor layout to sidebar style with QuickTime-like playback controls

### DIFF
--- a/src/components/PlayerPanels.tsx
+++ b/src/components/PlayerPanels.tsx
@@ -1,5 +1,4 @@
 import Timeline from "./Timeline";
-import SettingsPanel from "./SettingsPanel";
 import { useIsMobile } from "@/hooks/use-mobile";
 
 export default function PlayerPanels() {
@@ -7,17 +6,16 @@ export default function PlayerPanels() {
 
   if (isMobile) {
     return (
-      <div className="w-full flex flex-col gap-2">
+      <div className="w-full flex flex-col gap-2 mt-4">
         <Timeline />
-        <SettingsPanel />
       </div>
     );
   }
 
+  // Desktop: Floating QuickTime-style player at bottom center of main section
   return (
-    <div className="fixed right-4 top-4 flex flex-col gap-4 w-[480px]">
+    <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-50">
       <Timeline />
-      <SettingsPanel />
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { animationSettings } from "@/animations";
+import { useAnimationStore } from "@/stores/animationStore";
+import { Button } from "@/components/ui/button";
+import { LoaderPinwheel } from "lucide-react";
+
+const Sidebar = () => {
+  const selectedAnimationId = useAnimationStore((s) => s.selectedAnimationId);
+  const setSelectedAnimationId = useAnimationStore(
+    (s) => s.setSelectedAnimationId
+  );
+
+  const animationOptions = useMemo(
+    () =>
+      Object.entries(animationSettings).map(([key, s]) => ({
+        id: s.id,
+        name: s.name,
+        key,
+      })),
+    []
+  );
+
+  return (
+    <div className="w-64 bg-black border-r border-gray-800 flex flex-col h-full">
+      {/* Header */}
+      <div className="p-4 border-b border-gray-800">
+        <div className="flex items-center gap-2">
+          <LoaderPinwheel size={24} className="text-white" />
+          <span className="text-white text-xl font-bold">Sculptor</span>
+        </div>
+      </div>
+
+      {/* Animations List */}
+      <div className="flex-1 overflow-y-auto p-4">
+        <h3 className="text-sm font-medium text-white/50 mb-3 uppercase tracking-wider">
+          Animations
+        </h3>
+        <div className="space-y-2">
+          {animationOptions.map((animation) => (
+            <Button
+              key={animation.key}
+              variant={
+                selectedAnimationId === animation.id ? "default" : "ghost"
+              }
+              className={`w-full justify-start text-left ${
+                selectedAnimationId === animation.id
+                  ? "bg-white text-black hover:bg-white/90"
+                  : "text-white/70 hover:text-white hover:bg-white/10"
+              }`}
+              onClick={() => setSelectedAnimationId(animation.id)}
+            >
+              {animation.name}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/src/components/SketchView.tsx
+++ b/src/components/SketchView.tsx
@@ -5,14 +5,16 @@ const SketchView = () => {
   const { containerRef, settings } = usePlayback();
 
   return (
-    <div className="flex flex-col justify-start items-center h-full p-0 md:p-6 pt-4 md:pt-6 relative gap-0 md:gap-2">
-      <div className="mx-auto flex py-4 md:py-4 h-[auto] min-h-[0px] flex-shrink-1 flex-col relative w-full">
+    <div className="flex flex-col items-center justify-center h-full w-full relative p-6">
+      {/* Centered Canvas */}
+      <div className="flex items-center justify-center">
         <div
-          className="canvas-wrapper aspect-reels w-full flex items-center justify-center relative"
+          className="canvas-wrapper aspect-reels max-h-[80vh] max-w-[45vh] flex items-center justify-center relative"
           ref={containerRef}
         />
       </div>
 
+      {/* Playback Controls */}
       <PlayerPanels />
     </div>
   );

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -26,63 +26,73 @@ const Timeline = () => {
   };
 
   return (
-    <Panel>
-      <div className="flex items-end justify-between mb-2">
-        <div className="flex gap-2">
+    <div className="quicktime-player px-6 py-4">
+      <div className="flex flex-col gap-3 min-w-[500px]">
+        {/* Playback Controls */}
+        <div className="flex items-center justify-center gap-2">
           <Button
             size="sm"
             variant={isPlaying ? "secondary" : "default"}
             onClick={togglePlayback}
+            className="rounded-full w-10 h-10 p-0"
           >
-            {isPlaying ? <Pause size={16} /> : <Play size={16} />}
+            {isPlaying ? <Pause size={18} /> : <Play size={18} />}
           </Button>
-          <Button size="sm" variant="default" onClick={reset}>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={reset}
+            className="rounded-full w-9 h-9 p-0 hover:bg-white/20"
+          >
             <RotateCcw size={16} />
           </Button>
           <Button
             size="sm"
-            variant="default"
+            variant="ghost"
             onClick={() => setCurrentFrame(currentFrame - 1)}
             disabled={isPlaying || currentFrame === 0}
+            className="rounded-full w-9 h-9 p-0 hover:bg-white/20 disabled:opacity-30"
           >
             <StepBack size={16} />
           </Button>
           <Button
             size="sm"
-            variant="default"
+            variant="ghost"
             onClick={() => setCurrentFrame(currentFrame + 1)}
             disabled={isPlaying || currentFrame >= maxFrame}
+            className="rounded-full w-9 h-9 p-0 hover:bg-white/20 disabled:opacity-30"
           >
             <StepForward size={16} />
           </Button>
         </div>
-        <div className="text-xs font-mono">
+
+        {/* Timeline Slider */}
+        <Slider
+          value={[displayCurrentFrame]}
+          min={0}
+          step={1}
+          max={maxFrame}
+          onValueChange={handleSliderChange}
+          className="cursor-pointer"
+        />
+
+        {/* Frame Info */}
+        <div className="text-xs font-mono text-center text-white/70">
           <span>
-            Frame:{" "}
             {(displayCurrentFrame + 1)
               .toString()
               .padStart(displayTotalFrames.toString().length, "0")}
-            /
+            {" / "}
             {displayTotalFrames
               .toString()
               .padStart(displayTotalFrames.toString().length, "0")}
           </span>
-          <span className="ml-2 text-white/50">
-            ({(normalizedTime * 100).toFixed(2).padStart(6, "0")}% at {fps}{" "}
-            fps)
+          <span className="ml-3 text-white/40">
+            {(normalizedTime * 100).toFixed(1)}% · {fps} fps
           </span>
         </div>
       </div>
-
-      <Slider
-        value={[displayCurrentFrame]}
-        min={0}
-        step={1}
-        max={maxFrame}
-        onValueChange={handleSliderChange}
-        className="mt-2 mb-6"
-      />
-    </Panel>
+    </div>
   );
 };
 

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,20 +1,37 @@
-// Workspace hosts the SketchView and displays the Sculptor header.
+// Workspace hosts the Sidebar and SketchView in a sidebar layout.
 
-import { LoaderPinwheel } from "lucide-react";
+import Sidebar from "./Sidebar";
 import SketchView from "./SketchView";
+import SettingsPanel from "./SettingsPanel";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { LoaderPinwheel } from "lucide-react";
 
 const Workspace = () => {
   const isMobile = useIsMobile();
 
-  return (
-    <div className="workspace">
-      <main className="flex-1 overflow-hidden">
-        <div className="text-md md:text-xl font-bold absolute top-0 left-0 p-2 md:p-4 flex items-center gap-1 md:gap-2">
-          <LoaderPinwheel size={isMobile ? 20 : 24} className="text-white" />
-          <span className="text-white">Sculptor</span>
+  // Mobile layout: header + settings + canvas
+  if (isMobile) {
+    return (
+      <div className="flex flex-col h-full bg-black">
+        <div className="p-4 border-b border-gray-800">
+          <div className="flex items-center gap-2 mb-3">
+            <LoaderPinwheel size={20} className="text-white" />
+            <span className="text-white text-lg font-bold">Sculptor</span>
+          </div>
+          <SettingsPanel />
         </div>
+        <div className="flex-1 overflow-hidden main-section">
+          <SketchView />
+        </div>
+      </div>
+    );
+  }
 
+  // Desktop layout: sidebar + main section
+  return (
+    <div className="flex h-full">
+      <Sidebar />
+      <main className="flex-1 overflow-hidden main-section">
         <SketchView />
       </main>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,21 @@ body,
   background-size: 20px 20px;
 }
 
+/* Main section with dotted background */
+.main-section {
+  @apply relative;
+  background-color: #111;
+  background-image: radial-gradient(circle at 10px 10px, #333 1px, transparent 1px);
+  background-size: 20px 20px;
+}
+
+/* QuickTime-style player controls */
+.quicktime-player {
+  @apply rounded-2xl backdrop-blur-xl shadow-2xl;
+  background: rgba(20, 20, 20, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 /* Canvas aspect ratio container for 9:16 (Instagram Reels) */
 .aspect-reels {
   aspect-ratio: 9/16;


### PR DESCRIPTION
- Add new Sidebar component with animation buttons on the left
- Replace dropdown animation selector with clickable button list in sidebar
- Move canvas to centered position in main section with dotted background
- Reposition playback controls to bottom center as floating, semi-transparent panel
- Style Timeline component to resemble macOS QuickTime player controls
- Maintain mobile layout compatibility with compact header and settings
- Update workspace layout to flex container with sidebar and main section

https://claude.ai/code/session_019rJvz16cEogB7zrnP4uMr5